### PR TITLE
Remove jupyter install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ Mac User: https://www.tensorflow.org/versions/r1.2/install/install_mac#installin
 
 Ubuntu User: https://www.tensorflow.org/versions/r1.2/install/install_linux#installing_with_anaconda
 
-Install scikit-learn and jupyter in the same environment you installed TensorFlow
+Install scikit-learn in the same environment you installed TensorFlow
 
 ```
 conda install scikit-learn
-conda install jupyter
 ```


### PR DESCRIPTION
I think Anaconda comes equipped with Jupyter Notebook (See: http://jupyter.readthedocs.io/en/latest/install.html#installing-jupyter-using-anaconda-and-conda)